### PR TITLE
Check if settings are present before creating piwik

### DIFF
--- a/server/piwik.js
+++ b/server/piwik.js
@@ -1,5 +1,9 @@
 var PiwikTracker = Npm.require('piwik-tracker');
-var piwik = new PiwikTracker(Meteor.Settings.piwik.site_id, Meteor.Settings.piwik.url);
+if(typeof(Meteor.Settings.piwik) != 'undefined'){
+	var piwik = new PiwikTracker(Meteor.Settings.piwik.site_id, Meteor.Settings.piwik.url);	
+}else{
+	console.log("Pikik settings missing. Add settings to your settings.json file");
+}
 
 Meteor.methods({
   trackPage: function (url) {


### PR DESCRIPTION
I don't use settings.json in development environment, installing this package causes app crash. It would be great to avoid that crash and also start pikiw with custom variables (not from settings).